### PR TITLE
Add functionality to export volume-clipped point cloud to CSV

### DIFF
--- a/src/PointCloudOctree.js
+++ b/src/PointCloudOctree.js
@@ -62,31 +62,39 @@ export class PointCloudOctreeNode extends PointCloudTreeNode {
 			return null;
 		}
 
-		let buffer = this.geometryNode.buffer;
-
-		let posOffset = buffer.offset("position");
-		let stride = buffer.stride;
-		let view = new DataView(buffer.data);
-
-		let worldToBox = boxNode.matrixWorld.clone().invert();
-		let objectToBox = new THREE.Matrix4().multiplyMatrices(worldToBox, this.sceneNode.matrixWorld);
+		const attributes = this.geometryNode.geometry.attributes;
+		const position = attributes.position;
+		const worldToBox = boxNode.matrixWorld.clone().invert();
+		const objectToBox = new THREE.Matrix4().multiplyMatrices(
+			worldToBox,
+			this.sceneNode.matrixWorld
+		);
 
 		let inBox = [];
 
-		let pos = new THREE.Vector4();
-		for(let i = 0; i < buffer.numElements; i++){
-			let x = view.getFloat32(i * stride + posOffset + 0, true);
-			let y = view.getFloat32(i * stride + posOffset + 4, true);
-			let z = view.getFloat32(i * stride + posOffset + 8, true);
+		for (let i = 0; i < position.count; i++) {
+			const pos = new THREE.Vector3();
+			const arr = position.array;
+			const x = arr[3 * i];
+			const y = arr[3 * i + 1];
+			const z = arr[3 * i + 2];
 
-			pos.set(x, y, z, 1);
+			pos.set(x, y, z);
+
 			pos.applyMatrix4(objectToBox);
 
-			if(-0.5 < pos.x && pos.x < 0.5){
-				if(-0.5 < pos.y && pos.y < 0.5){
-					if(-0.5 < pos.z && pos.z < 0.5){
-						pos.set(x, y, z, 1).applyMatrix4(this.sceneNode.matrixWorld);
-						inBox.push(new THREE.Vector3(pos.x, pos.y, pos.z));
+			if (-0.5 < pos.x && pos.x < 0.5) {
+				if (-0.5 < pos.y && pos.y < 0.5) {
+					if (-0.5 < pos.z && pos.z < 0.5) {
+						let point = new THREE.Vector3(x, y, z);
+						point.applyMatrix4(this.sceneNode.matrixWorld);
+						position.array[3 * i] = point.x;
+						position.array[3 * i + 1] = point.y;
+						position.array[3 * i + 2] = point.z;
+
+						inBox.push(position.array[3 * i]);
+						inBox.push(position.array[3 * i + 1]);
+						inBox.push(position.array[3 * i + 2]);
 					}
 				}
 			}

--- a/src/utils/VolumeTool.js
+++ b/src/utils/VolumeTool.js
@@ -3,6 +3,8 @@ import * as THREE from "../../libs/three.js/build/three.module.js";
 import {Volume, BoxVolume} from "./Volume.js";
 import {Utils} from "../utils.js";
 import { EventDispatcher } from "../EventDispatcher.js";
+import { CSVExporter } from "../exporter/CSVExporter.js";
+import { Points } from "../Points.js";
 
 export class VolumeTool extends EventDispatcher{
 	constructor (viewer) {
@@ -164,4 +166,33 @@ export class VolumeTool extends EventDispatcher{
 		renderer.setRenderTarget(oldTarget);
 	}
 
+	collectPointsFromVolume(volume, pointCloud) {
+		const pointNodes = pointCloud.visibleNodes.map((node, _) => {
+			return node.getPointsInBox(volume);
+		});
+
+		const flatNodes = pointNodes.flat();
+		let points = new Points();
+		points.numPoints = flatNodes.length / 3; // 3 because xyz
+		points.data["position"] = new Float64Array(flatNodes);
+
+		return points;
+	}
+
+	exportVolumePointsToCSV() {
+        const volumes = this.viewer.scene.volumes;
+        const pointCloud = this.viewer.scene.pointclouds[0];
+
+        let urls = [];
+
+        for (let volume of volumes) {
+            let points = this.collectPointsFromVolume(volume, pointCloud);
+
+            let string = CSVExporter.toString(points);
+            let blob = new Blob([string], { type: "text/csv;charset=utf-8" });
+            let url = URL.createObjectURL(blob);
+            urls.push(url);
+        }
+        return urls;
+    }
 }

--- a/src/utils/VolumeTool.js
+++ b/src/utils/VolumeTool.js
@@ -180,19 +180,19 @@ export class VolumeTool extends EventDispatcher{
 	}
 
 	exportVolumePointsToCSV() {
-        const volumes = this.viewer.scene.volumes;
-        const pointCloud = this.viewer.scene.pointclouds[0];
+		const volumes = this.viewer.scene.volumes;
+		const pointCloud = this.viewer.scene.pointclouds[0];
 
-        let urls = [];
+		let urls = [];
 
-        for (let volume of volumes) {
-            let points = this.collectPointsFromVolume(volume, pointCloud);
+		for (let volume of volumes) {
+			let points = this.collectPointsFromVolume(volume, pointCloud);
 
-            let string = CSVExporter.toString(points);
-            let blob = new Blob([string], { type: "text/csv;charset=utf-8" });
-            let url = URL.createObjectURL(blob);
-            urls.push(url);
-        }
-        return urls;
-    }
+			let string = CSVExporter.toString(points);
+			let blob = new Blob([string], { type: "text/csv;charset=utf-8" });
+			let url = URL.createObjectURL(blob);
+			urls.push(url);
+		}
+		return urls;
+	}
 }


### PR DESCRIPTION
### 追加機能
Potree Viewerからクリッピングしたボリュームに含まれる点群のポイント情報をCSV形式でエクスポートする機能を追加。

### 備考
当初は、Potree Viewer上でVolumeに含まれるポイント情報を切り出し、LASExporterで点群ファイルを生成することを想定していた。
しかし、Potree Viewerはoctree形式のデータをユーザー操作に応じて動的に追加読み込みする仕様になっており、以下の問題が発生した。
- 追加読み込みの状況によって、生成される点群のポイント数が減少する。
- boundingBoxなどのメタデータ設定に不整合が生じる。

これらの問題を回避するため、Potree Viewerからフィルタリング対象のポイント情報をCSV形式でエクスポートし、別のシステムで`pdal`を使用して点群を編集する方針に変更。

参考
https://github.com/potree/potree/issues/1349